### PR TITLE
Support stubbing mw.template.get().render()

### DIFF
--- a/src/mockMediaWiki.js
+++ b/src/mockMediaWiki.js
@@ -72,7 +72,11 @@ module.exports = function newMockMediaWiki() {
 		msg: function ( id ) { return id; },
 		now: Date.now.bind( Date ),
 		template: {
-			get: function () {}
+			get: function () {
+				return {
+					render: function () {}
+				};
+			}
 		},
 		user: {
 			options: {


### PR DESCRIPTION
I'd like to try to use the latest version of mw-node-qunit in our new
MachineVision Extension. Changing the stub of mw.template.get() to return an
object with a stub render supports our usage.