### PR TITLE
Mock mediawiki messages can be escaped

### DIFF
--- a/src/mockMediaWiki.js
+++ b/src/mockMediaWiki.js
@@ -65,6 +65,7 @@ module.exports = function newMockMediaWiki() {
 		},
 		message: function () {
 			return {
+				escaped: function () {},
 				text: function () {},
 				parse: function () {}
 			};


### PR DESCRIPTION
This is blocking https://gerrit.wikimedia.org/r/c/mediawiki/extensions/MobileFrontend/+/572487