### PR TITLE
Prepare 6.3.0 Release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@wikimedia/mw-node-qunit",
-	"version": "6.2.1",
+	"version": "6.3.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@wikimedia/mw-node-qunit",
-			"version": "6.2.1",
+			"version": "6.3.0",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"eslint-config-wikimedia": "0.21.0",
@@ -1029,7 +1029,8 @@
 				"esprima": "^4.0.1",
 				"estraverse": "^5.2.0",
 				"esutils": "^2.0.2",
-				"optionator": "^0.8.1"
+				"optionator": "^0.8.1",
+				"source-map": "~0.6.1"
 			},
 			"bin": {
 				"escodegen": "bin/escodegen.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wikimedia/mw-node-qunit",
-	"version": "6.2.1",
+	"version": "6.3.0",
 	"description": "Node CLI qunit runner with mediawiki additions",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
I have, potentially wrongly, identified version 6.2.1 to be a reason why linting jobs of MobileFrontend extension (LTS REL1_35 branch at least) on WMF's Jenkins CI fail. That version results in MobileFrontend installing eslint version 6.8, whereas plugins used by eslint-config-wikimedia 0.21 actually seem to require eslint 7.